### PR TITLE
Reduce dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "detect-indent": "^6.0.0",
     "inquirer": "^7.3.3",
     "messageformat-parser": "^4.1.0",
-    "prettify-xml": "^1.2.0",
     "xml2js": "https://github.com/fkirc/node-xml2js/tarball/21de47581c46ce5b5659448ab198501786d2117d"
   },
   "devDependencies": {

--- a/src/file-formats/android-xml/xml-write.ts
+++ b/src/file-formats/android-xml/xml-write.ts
@@ -10,11 +10,16 @@ export function writeXmlResourceFile(
 ) {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const xml2js = require("xml2js");
+  const stringIndent = " ".repeat(indent);
   const options: OptionsV2 = {
     xmldec: {
       version: "1.0",
       encoding: "utf-8",
       standalone: undefined,
+    },
+    renderOpts: {
+      pretty: true,
+      indent: stringIndent,
     },
   };
   // See https://github.com/oozcitak/xmlbuilder-js/wiki/Builder-Options for available xmlBuilderOptions
@@ -25,11 +30,6 @@ export function writeXmlResourceFile(
   const mergedOptions = { ...options, xmlBuilderOptions };
   const builder: Builder = new xml2js.Builder(mergedOptions);
   const rawXmlString: string = builder.buildObject(resourceFile);
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const prettifyXml = require("prettify-xml");
-  const prettyXmlString = prettifyXml(rawXmlString, {
-    indent,
-  });
-  const xmlString = `${prettyXmlString}\n`;
+  const xmlString = `${rawXmlString}\n`;
   writeUf8File(args.path, xmlString);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3882,11 +3882,6 @@ prettier@^2.1.2:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
   integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
 
-prettify-xml@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/prettify-xml/-/prettify-xml-1.2.0.tgz#46dcf1ee8a8d8b73db30b7e06ef26dc9cf3f6f18"
-  integrity sha1-Rtzx7oqNi3PbMLfgbvJtyc8/bxg=
-
 pretty-format@^25.2.1, pretty-format@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.5.0.tgz#7873c1d774f682c34b8d48b6743a2bf2ac55791a"


### PR DESCRIPTION
`xmlbuilder-js` seems to be powerful enough such that a separate prettifier is not necessary: https://github.com/fkirc/xmlbuilder-js/tree/attranslate