### PR TITLE
Update po-ops.ts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,7 @@ name: Tests
 
 on:
   push:
-    branches:
-      - '**'
+  pull_request:
   workflow_dispatch:
     inputs:
       release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master
+        cancel_others: 'false'
         with:
           paths_ignore: '["**/*.md"]'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master
-        cancel_others: 'false'
         with:
+          cancel_others: 'false'
           paths_ignore: '["**/*.md"]'
 
   ci:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.4.1
+
+- Fix crash for PO/POT-files without a header
+
 # 1.4.0
 
 - Change default of `--overwriteOutdated` from `true` to `false`

--- a/sample-scripts/po-generic/en.po
+++ b/sample-scripts/po-generic/en.po
@@ -1,19 +1,4 @@
 # SOME DESCRIPTIVE TITLE.
-msgid ""
-msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-01-16 23:23+0000\n"
-"PO-Revision-Date: 2019-12-04 12:12+0000\n"
-"Last-Translator: Orla\n"
-"Language-Team: English <http://197.167.0.100/projects/\n"
-"Language: en\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: attranslate\n"
-
 # lh-check { min: 10, max: 15 }
 msgid "Made with ❤"
 msgstr ""

--- a/sample-scripts/po-generic/es.po
+++ b/sample-scripts/po-generic/es.po
@@ -1,4 +1,3 @@
-# SOME DESCRIPTIVE MODIFIED TITLE.
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/src/file-formats/po/po-ops.ts
+++ b/src/file-formats/po/po-ops.ts
@@ -78,7 +78,7 @@ export function parsePotFile(
   try {
     const potFile = po.parse(rawFile);
     if (!potFile.headers) {
-      potFile.headers = new Object;
+      potFile.headers = {};
     }
     potFile.headers["X-Generator"] = "attranslate";
     return potFile;

--- a/src/file-formats/po/po-ops.ts
+++ b/src/file-formats/po/po-ops.ts
@@ -77,6 +77,9 @@ export function parsePotFile(
 ): GetTextTranslations {
   try {
     const potFile = po.parse(rawFile);
+    if (!potFile.headers) {
+      potFile.headers = new Object;
+    }
     potFile.headers["X-Generator"] = "attranslate";
     return potFile;
   } catch (e) {

--- a/test-assets/po/sample.pot
+++ b/test-assets/po/sample.pot
@@ -1,5 +1,8 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain\n"
+"X-Generator: attranslate\n"
 
-# Check whether parsing works even without a header
 msgid "A section of text like this is known as a text segment."
 msgstr "First"
 

--- a/test-assets/po/sample.pot
+++ b/test-assets/po/sample.pot
@@ -1,8 +1,5 @@
-msgid ""
-msgstr ""
-"Content-Type: text/plain\n"
-"X-Generator: attranslate\n"
 
+# Check whether parsing works even without a header
 msgid "A section of text like this is known as a text segment."
 msgstr "First"
 


### PR DESCRIPTION
Not all tools (fex https://github.com/lukaskabrt/PoExtractor) generate a header in the PO/POT file. 
Without this change the tool crashes:

```
% attranslate --srcFile ./src.pot --targetFile ./en.po --targetLng en --srcLng nb --targetFormat=po --srcFormat=po  
TypeError: Cannot set property 'X-Generator' of undefined
    at Object.parsePotFile (.nvm/versions/node/v10.16.3/lib/node_modules/attranslate/dist/file-formats/po/po-ops.js:62:40)
    at PoFile.readTFile (.nvm/versions/node/v10.16.3/lib/node_modules/attranslate/dist/file-formats/po/po-files.js:15:34)
    at Object.readTFileCore (.nvm/versions/node/v10.16.3/lib/node_modules/attranslate/dist/core/core-util.js:49:34)
    at process._tickCallback (internal/process/next_tick.js:68:7)
    at Function.Module.runMain (internal/modules/cjs/loader.js:834:11)
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:622:3)
error: Failed to parse './src.pot' with expected format 'po': GetText parsing error
```