### PR TITLE
Fix problem with too short OpenAI-responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.9.2
+
+- Fix problem with too short OpenAI responses
+
+# 1.9.1
+
+- Attempt to improve error messages for OpenAI
+
 # 1.9.0
 
 - Add support for OpenAI translations (ChatGPT)

--- a/src/services/openai-translate.ts
+++ b/src/services/openai-translate.ts
@@ -35,6 +35,7 @@ async function translateSingleString(
       model: "text-davinci-003",
       prompt,
       temperature: 0.2,
+      max_tokens: 2048,
     });
     const text = completion.data.choices[0].text;
     if (text == undefined) {


### PR DESCRIPTION
Setting max_tokens according to https://platform.openai.com/docs/api-reference/completions/create#completions/create-max_tokens

<!---
Thank you for your pull request. 
Please provide a short description on why the pull request is needed.
-->
