### PR TITLE
Fix invalid typescript interfaces

### DIFF
--- a/src/services/typechat.ts
+++ b/src/services/typechat.ts
@@ -23,7 +23,7 @@ function generateSchema(
 ): string {
   const properties = batch
     .map((tString: TString) => {
-      return `  ${tString.key}: string;`;
+      return `  '${tString.key}': string;`;
     })
     .join("\n");
 


### PR DESCRIPTION
The generated Typescript interface for nested values is invalid.

e.g. the following json file
```javascript
// en.json
{
  "state": {
    "ready": "Ready"
  }
}
```

will produce the following interface.
```typescript
export interface AppLocalizations {
  state.ready: string  // the key state.ready should be enclosed in quotes
}
```