### PR TITLE
doc: Add Contributors Section to README

### DIFF
--- a/README-es.md
+++ b/README-es.md
@@ -119,3 +119,9 @@ Este prompt asegurará que los términos técnicos permanezcan en inglés mientr
 - Solicitar reglas específicas de capitalización
 - Proporcionar contexto sobre el dominio de tu aplicación
 - Establecer preferencias de tono o estilo para las traducciones
+
+# Contribuidores
+
+Nos gustaría agradecer a todos los contribuidores que han ayudado a mejorar attranslate:
+
+- [@esuljic](https://github.com/esuljic): Agregó la característica de parámetro de prompt para servicios de IA (OpenAI y TypeChat).

--- a/README.md
+++ b/README.md
@@ -118,3 +118,9 @@ This prompt will ensure that technical terms remain in English while translating
 - Requesting specific capitalization rules
 - Providing context about your application domain
 - Setting tone or style preferences for translations
+
+# Contributors
+
+We would like to thank all contributors who have helped improve attranslate:
+
+- [@esuljic](https://github.com/esuljic): Added the prompt parameter feature for AI services (OpenAI and TypeChat).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "attranslate",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "attranslate",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "GPL",
       "dependencies": {
         "@google-cloud/translate": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attranslate",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Semi-automated Text Translator for Websites and Apps",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Overview
This PR adds a Contributors section to both English and Spanish README files to acknowledge and thank contributors for their work on the project.

## Changes
- Added Contributors section to `README.md`
- Added Contribuidores section to `README-es.md`
- Included first contributor [@esuljic](https://github.com/esuljic) for adding the prompt parameter feature
- Increased version to 2.2.1

This helps maintain proper attribution and recognition for community contributions to the project.
