### PR TITLE
feat: Add key-as-translation service

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Therefore, whenever you are unhappy with the produced text, `attranslate` allows
 - [azure](https://azure.microsoft.com/en-us/services/cognitive-services/translator-text-api/): Needs a Microsoft account; costs money
 - `sync-without-translate`: Does not change the language. This can be useful for converting between file formats, or for maintaining region-specific differences.
 - `manual`: Translates text with manual typing
+- `key-as-translation`: Uses the key as the translation, useful for debugging or placeholder translations.
+- [`typechat`](./docs/TypeChat.md): Translates text using OpenAI's language models or a self-hosted model with an OpenAI-compatible API.
+- [`typechat-manual`](./docs/TypeChat.md): Provides manual translation workflows by leveraging clipboard operations.
 
 # Usage Examples
 
@@ -79,27 +82,28 @@ Run `attranslate --help` to see a list of available options:
 Usage: attranslate [options]
 
 Options:
-  --srcFile <sourceFile>              The source file to be translated
-  --srcLng <sourceLanguage>           A language code for the source language
-  --srcFormat <sourceFileFormat>      One of "flat-json", "nested-json",
-                                      "yaml", "po", "xml", "ios-strings",
-                                      "arb", "csv"
-  --targetFile <targetFile>           The target file for the translations
-  --targetLng <targetLanguage>        A language code for the target language
-  --targetFormat <targetFileFormat>   One of "flat-json", "nested-json",
-                                      "yaml", "po", "xml", "ios-strings",
-                                      "arb", "csv"
-  --service <translationService>      One of "openai", "manual",
-                                      "sync-without-translate",
-                                      "google-translate", "azure"
-  --serviceConfig <serviceKey>        supply configuration for a translation
-                                      service (either a path to a key-file or
-                                      an API-key)
-  --matcher <matcher>                 An optional feature for string replacements. One of "none", "icu", "i18next",
-                                      "sprintf" (default: "none")
-  --prompt <customPrompt>             Optional custom prompt to guide the translation service. Useful for specifying
-                                      technical terms that should not be translated or other translation preferences.
-  -v, --version                       output the version number
+  --srcFile <sourceFile>             The source file to be translated
+  --srcLng <sourceLanguage>          A language code for the source language
+  --srcFormat <sourceFileFormat>     One of "flat-json", "nested-json", "yaml",
+                                     "po", "xml", "ios-strings", "arb", "csv"
+  --targetFile <targetFile>          The target file for the translations
+  --targetLng <targetLanguage>       A language code for the target language
+  --targetFormat <targetFileFormat>  One of "flat-json", "nested-json", "yaml",
+                                     "po", "xml", "ios-strings", "arb", "csv"
+  --service <translationService>     One of "openai", "typechat",
+                                     "typechat-manual", "manual",
+                                     "sync-without-translate",
+                                     "google-translate", "azure",
+                                     "key-as-translation"
+  --serviceConfig <serviceKey>       supply configuration for a translation
+                                     service (either a path to a key-file or an
+                                     API-key)
+  --matcher <matcher>                One of "none", "icu", "i18next", "sprintf"
+                                     (default: "none")
+  --prompt <prompt>                  supply a prompt for the AI translation
+                                     service
+  -v, --version                      output the version number
+  -h, --help                         display help for command
 ```
 
 ## Prompt Examples

--- a/docs/TypeChat.md
+++ b/docs/TypeChat.md
@@ -1,0 +1,39 @@
+# TypeChat Documentation
+
+## Description
+
+The `typechat` service is for translating your files using OpenAI's language models or any self-hosted model with an OpenAI-compatible API.
+The `typechat-manual` service provides a manual translation workflow by leveraging clipboard operations.
+
+## Environment Variables
+
+The following environment variables can be configured:
+
+| Name                      | Description                                | Default                                      |
+|---------------------------|--------------------------------------------|----------------------------------------------|
+| `OPENAI_API_KEY`          | API key for OpenAI authentication.         |                                              |
+| `OPENAI_ENDPOINT`         | OpenAI API endpoint URL.                   | `https://api.openai.com/v1/chat/completions` |
+| `OPENAI_MODEL`            | Model to use for translation.              | `gpt-4o-mini-2024-07-18`                     |
+| `OPEN_AI_BATCH_SIZE`      | Number of strings to process in a batch.   | `10`                                         |
+| `TYPECHAT_SCHEMA_NAME`    | Name for the generated schema.             | `AppLocalizations`                           |
+| `TYPECHAT_SCHEMA_COMMENT` | Optional comment for the generated schema. |                                              |
+
+## Usage Example
+
+Below is an example of how to use `typechat` with a bash script:
+
+```bash
+#!/bin/bash
+
+# Set environment variables
+export OPENAI_API_KEY="your_openai_api_key"
+export OPENAI_ENDPOINT="https://api.openai.com/v1/chat/completions"
+export OPENAI_MODEL="gpt-4o-mini-2024-07-18"
+export OPEN_AI_BATCH_SIZE="20"
+
+# TYPECHAT_SCHEMA_COMMENT can be used to give the model more context
+export TYPECHAT_SCHEMA_COMMENT="Translations for a chess game"
+
+# Run attranslate
+attranslate --srcFormat=yaml --targetFormat=yaml --srcFile=en.yaml --targetFile=de.xml --srcLng=English --targetLng=German --service=typechat
+```

--- a/src/core/invoke-translation-service.ts
+++ b/src/core/invoke-translation-service.ts
@@ -29,12 +29,12 @@ export async function invokeTranslationService(
   const rawInputs: TString[] = [];
   const results: TSet = new Map();
   serviceInputs.forEach((value, key) => {
-    if (!value || !value.trim().length) {
+    if (args.service != 'key-as-translation' && (!value || !value.trim().length)) {
       results.set(key, value);
     } else {
       rawInputs.push({
         key,
-        value,
+        value: value ?? "",
       });
     }
   });

--- a/src/services/key-as-translation.ts
+++ b/src/services/key-as-translation.ts
@@ -1,0 +1,20 @@
+import { TResult, TService, TServiceArgs } from "./service-definitions";
+import { logFatal } from "../util/util";
+
+export class KeyAsTranslation implements TService {
+  translateStrings(args: TServiceArgs): Promise<TResult[]> {
+    if (args.srcLng !== args.targetLng) {
+      logFatal(
+        `'key-as-translation' cannot translate between different languages -> You should either use equal languages or a different service`
+      );
+    }
+    return Promise.resolve(
+      args.strings.map((tString) => {
+        return {
+          key: tString.key,
+          translated: tString.key,
+        };
+      })
+    );
+  }
+}

--- a/src/services/service-definitions.ts
+++ b/src/services/service-definitions.ts
@@ -37,6 +37,7 @@ const serviceMap = {
   "google-translate": null,
   // deepl: null,
   azure: null,
+  "key-as-translation": null,
 };
 
 export function injectFakeService(serviceName: string, service: TService) {
@@ -77,5 +78,7 @@ export async function instantiateTService(
       return new (
         await import("./sync-without-translate")
       ).SyncWithoutTranslate();
+    case "key-as-translation":
+      return new (await import("./key-as-translation")).KeyAsTranslation();
   }
 }

--- a/src/services/typechat.ts
+++ b/src/services/typechat.ts
@@ -87,7 +87,7 @@ function createLanguageModel(
 ): TypeChatLanguageModel {
   const apiKey =
     env.OPENAI_API_KEY ?? missingEnvironmentVariable("OPENAI_API_KEY");
-  const model = env.OPENAI_MODEL ?? "gpt-3.5-turbo-instruct";
+  const model = env.OPENAI_MODEL ?? "gpt-4o-mini-2024-07-18";
   const url =
     env.OPENAI_ENDPOINT ?? "https://api.openai.com/v1/chat/completions";
 


### PR DESCRIPTION
Hi,

I added a new service called `key-as-translation`. It is very similar to `sync-without-translate`. As the name suggests, the key is used as value.
I also added a short description for the TypeChat service.

I hope you don't mind that I put all commits into one PR.